### PR TITLE
Hardcode dev origin to localhost:3000

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,6 @@
 import type { NextConfig } from "next";
-import { env } from "process";
-
 const nextConfig: NextConfig = {
-  allowedDevOrigins: [env.REPLIT_DOMAINS.split(",")[0]],
+  allowedDevOrigins: ["http://localhost:3000"],
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- simplify development origin configuration by hardcoding http://localhost:3000

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df42e6e8808327b73ce3a3cd00d4e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development configuration to use a single local origin (http://localhost:3000), removing reliance on external domain lists. This streamlines local setup and reduces environment-specific variability.
* **No User-Facing Changes**
  * This update only affects development environments and does not alter production behavior or visible app features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->