### PR TITLE
Add markdown-synced document state to editor

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -1,35 +1,55 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/ariakit";
-import { Block } from "@blocknote/core";
+import { BlockNoteEditor } from "@blocknote/core";
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/ariakit/style.css";
 
+import { EditorDocument, serializeBlocksToMarkdown } from "../lib/document";
+
 interface EditorProps {
-  content: Block[];
-  onChange: (blocks: Block[]) => void;
+  document: EditorDocument;
+  onChange: (doc: EditorDocument) => void;
+  onEditorReady?: (editor: BlockNoteEditor<any, any, any>) => void;
 }
 
-export default function Editor({ content, onChange }: EditorProps) {
+export default function Editor({ document, onChange, onEditorReady }: EditorProps) {
+  const initialContent = useMemo(() => {
+    if (document.blocks.length === 0) {
+      return undefined;
+    }
+    return document.blocks;
+  }, [document.blocks]);
+
   const editor = useCreateBlockNote({
-    initialContent: content.length > 0 ? content : undefined,
+    initialContent,
   });
 
-  // Synchronizacja zewnętrznych zmian (z akcji CopilotKit) do edytora
   useEffect(() => {
-    if (content.length > 0) {
-      const currentBlocks = editor.document;
-
-      // Sprawdź czy treść się różni (uniknięcie pętli)
-      const isDifferent = JSON.stringify(currentBlocks) !== JSON.stringify(content);
-
-      if (isDifferent) {
-        editor.replaceBlocks(editor.document, content);
-      }
+    if (onEditorReady) {
+      onEditorReady(editor);
     }
-  }, [content, editor]);
+  }, [editor, onEditorReady]);
+
+  useEffect(() => {
+    const currentBlocks = editor.document;
+    const incomingBlocks = document.blocks;
+
+    if (incomingBlocks.length === 0) {
+      if (currentBlocks.length > 0) {
+        editor.replaceBlocks(currentBlocks, incomingBlocks);
+      }
+      return;
+    }
+
+    const isDifferent = JSON.stringify(currentBlocks) !== JSON.stringify(incomingBlocks);
+
+    if (isDifferent) {
+      editor.replaceBlocks(editor.document, incomingBlocks);
+    }
+  }, [document.blocks, editor]);
 
   return (
     <div className="h-full w-full flex flex-col">
@@ -37,7 +57,11 @@ export default function Editor({ content, onChange }: EditorProps) {
         editor={editor}
         onChange={() => {
           const blocks = editor.document;
-          onChange(blocks);
+          const markdown = serializeBlocksToMarkdown(blocks, editor);
+          onChange({
+            blocks,
+            markdown,
+          });
         }}
         className="flex-1 min-h-0"
       />

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -1,28 +1,81 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useCopilotReadable, useCopilotAction } from "@copilotkit/react-core";
 import { CopilotSidebar } from "@copilotkit/react-ui";
-import { Block } from "@blocknote/core";
+import { BlockNoteEditor } from "@blocknote/core";
 import dynamic from "next/dynamic";
 import "@copilotkit/react-ui/styles.css";
+
+import {
+  EditorDocument,
+  buildMarkdownForBlockType,
+  createBlockFromMarkdownSnippet,
+  ensureBlockIds,
+  extractPlainTextFromBlock,
+  serializeBlocksToMarkdown,
+} from "../lib/document";
 
 const Editor = dynamic(() => import("./Editor"), { ssr: false });
 
 export default function MainView() {
-  // Stan dokumentu
-  const [content, setContent] = useState<Block[]>([]);
+  const [documentState, setDocumentState] = useState<EditorDocument>({
+    blocks: [],
+    markdown: "",
+  });
+  const editorRef = useRef<BlockNoteEditor<any, any, any> | null>(null);
 
-  // Udostępnianie treści dokumentu asystentowi
+  const setEditor = useCallback((editor: BlockNoteEditor<any, any, any>) => {
+    editorRef.current = editor;
+  }, []);
+
+  const computeMarkdown = useCallback(
+    (blocks: EditorDocument["blocks"]) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return documentState.markdown;
+      }
+      return serializeBlocksToMarkdown(blocks, editor);
+    },
+    [documentState.markdown]
+  );
+
+  const applyBlocksUpdate = useCallback(
+    (updater: (blocks: EditorDocument["blocks"]) => EditorDocument["blocks"]) => {
+      setDocumentState((prev) => {
+        const editor = editorRef.current;
+        if (!editor) {
+          return prev;
+        }
+
+        const updatedBlocks = ensureBlockIds(updater(prev.blocks));
+        const markdown = serializeBlocksToMarkdown(updatedBlocks, editor);
+
+        return {
+          blocks: updatedBlocks,
+          markdown,
+        };
+      });
+    },
+    []
+  );
+
   useCopilotReadable({
-    description: "Zawartość dokumentu edytora - wszystkie bloki tekstu",
-    value: content,
+    description: "Zawartość dokumentu edytora wraz z reprezentacją markdown",
+    value: {
+      blocks: documentState.blocks,
+      markdown: documentState.markdown,
+      metadata: {
+        blockCount: documentState.blocks.length,
+        blockIds: documentState.blocks.map((block) => block.id),
+      },
+    },
   });
 
-  // Akcja: Wstawianie nowego bloku tekstu
   useCopilotAction({
     name: "insertBlock",
-    description: "Wstawia nowy blok tekstu w dokumencie na określonej pozycji. Jeśli pozycja nie jest podana, dodaje na końcu.",
+    description:
+      "Wstawia nowy blok tekstu w dokumencie na określonej pozycji. Jeśli pozycja nie jest podana, dodaje na końcu.",
     parameters: [
       {
         name: "text",
@@ -39,36 +92,39 @@ export default function MainView() {
       {
         name: "position",
         type: "number",
-        description: "Pozycja (indeks), na której wstawić blok. Jeśli nie podano, wstawi na końcu.",
+        description:
+          "Pozycja (indeks), na której wstawić blok. Jeśli nie podano, wstawi na końcu.",
         required: false,
       },
     ],
     handler: async ({ text, type = "paragraph", position }) => {
-      const newBlock: Block = {
-        id: crypto.randomUUID(),
-        type: type as any,
-        content: text,
-        children: [],
-      };
+      const editor = editorRef.current;
+      if (!editor) {
+        throw new Error("Edytor nie jest jeszcze gotowy. Spróbuj ponownie, gdy pojawi się interfejs edytora.");
+      }
 
-      setContent((prevContent) => {
-        const newContent = [...prevContent];
-        if (position !== undefined && position >= 0 && position <= newContent.length) {
-          newContent.splice(position, 0, newBlock);
+      applyBlocksUpdate((prevBlocks) => {
+        const newBlocks = [...prevBlocks];
+        const markdownSnippet = buildMarkdownForBlockType(text, type);
+        const newBlock = createBlockFromMarkdownSnippet(markdownSnippet, editor);
+
+        if (position !== undefined && position >= 0 && position <= newBlocks.length) {
+          newBlocks.splice(position, 0, newBlock);
         } else {
-          newContent.push(newBlock);
+          newBlocks.push(newBlock);
         }
-        return newContent;
+
+        return newBlocks;
       });
 
-      return `Wstawiono blok "${text}" na pozycji ${position ?? content.length}`;
+      return `Wstawiono blok "${text}" na pozycji ${position ?? documentState.blocks.length}`;
     },
   });
 
-  // Akcja: Edycja istniejącego bloku
   useCopilotAction({
     name: "updateBlock",
-    description: "Aktualizuje treść lub typ istniejącego bloku na podstawie jego pozycji (indeksu).",
+    description:
+      "Aktualizuje treść lub typ istniejącego bloku na podstawie jego pozycji (indeksu).",
     parameters: [
       {
         name: "position",
@@ -90,30 +146,39 @@ export default function MainView() {
       },
     ],
     handler: async ({ position, text, type }) => {
-      setContent((prevContent) => {
-        if (position < 0 || position >= prevContent.length) {
-          throw new Error(`Nieprawidłowa pozycja: ${position}. Dokument ma ${prevContent.length} bloków.`);
+      const editor = editorRef.current;
+      if (!editor) {
+        throw new Error("Edytor nie jest jeszcze gotowy. Spróbuj ponownie, gdy pojawi się interfejs edytora.");
+      }
+
+      applyBlocksUpdate((prevBlocks) => {
+        if (position < 0 || position >= prevBlocks.length) {
+          throw new Error(
+            `Nieprawidłowa pozycja: ${position}. Dokument ma ${prevBlocks.length} bloków.`
+          );
         }
 
-        const newContent = [...prevContent];
-        const block = { ...newContent[position] };
+        const newBlocks = [...prevBlocks];
+        const targetBlock = { ...newBlocks[position] };
 
-        if (text !== undefined) {
-          block.content = text;
-        }
-        if (type !== undefined) {
-          block.type = type as any;
+        if (text !== undefined || type !== undefined) {
+          const baseText = text ?? extractPlainTextFromBlock(targetBlock);
+          const markdownSnippet = buildMarkdownForBlockType(
+            baseText,
+            type ?? (targetBlock.type as string)
+          );
+          const updatedBlock = createBlockFromMarkdownSnippet(markdownSnippet, editor);
+          updatedBlock.id = targetBlock.id;
+          newBlocks[position] = updatedBlock;
         }
 
-        newContent[position] = block;
-        return newContent;
+        return newBlocks;
       });
 
       return `Zaktualizowano blok na pozycji ${position}`;
     },
   });
 
-  // Akcja: Usuwanie bloku
   useCopilotAction({
     name: "deleteBlock",
     description: "Usuwa blok tekstu z dokumentu na podstawie jego pozycji (indeksu).",
@@ -126,21 +191,22 @@ export default function MainView() {
       },
     ],
     handler: async ({ position }) => {
-      setContent((prevContent) => {
-        if (position < 0 || position >= prevContent.length) {
-          throw new Error(`Nieprawidłowa pozycja: ${position}. Dokument ma ${prevContent.length} bloków.`);
+      applyBlocksUpdate((prevBlocks) => {
+        if (position < 0 || position >= prevBlocks.length) {
+          throw new Error(
+            `Nieprawidłowa pozycja: ${position}. Dokument ma ${prevBlocks.length} bloków.`
+          );
         }
 
-        const newContent = [...prevContent];
-        newContent.splice(position, 1);
-        return newContent;
+        const newBlocks = [...prevBlocks];
+        newBlocks.splice(position, 1);
+        return newBlocks;
       });
 
       return `Usunięto blok na pozycji ${position}`;
     },
   });
 
-  // Akcja: Zastąpienie całej zawartości dokumentu
   useCopilotAction({
     name: "replaceAllContent",
     description: "Zastępuje całą zawartość dokumentu nowymi blokami tekstu.",
@@ -148,35 +214,47 @@ export default function MainView() {
       {
         name: "blocks",
         type: "object[]",
-        description: "Tablica nowych bloków. Każdy blok powinien mieć 'text' i opcjonalnie 'type' (domyślnie 'paragraph')",
+        description:
+          "Tablica nowych bloków. Każdy blok powinien mieć 'text' i opcjonalnie 'type' (domyślnie 'paragraph')",
         required: true,
       },
     ],
     handler: async ({ blocks }) => {
-      const newBlocks: Block[] = blocks.map((b: any) => ({
-        id: crypto.randomUUID(),
-        type: (b.type || "paragraph") as any,
-        content: b.text || "",
-        children: [],
-      }));
+      const editor = editorRef.current;
+      if (!editor) {
+        throw new Error("Edytor nie jest jeszcze gotowy. Spróbuj ponownie, gdy pojawi się interfejs edytora.");
+      }
 
-      setContent(newBlocks);
+      const newBlocks = ensureBlockIds(
+        blocks.map((b: any) =>
+          createBlockFromMarkdownSnippet(buildMarkdownForBlockType(b.text || "", b.type), editor)
+        )
+      );
+
+      const markdown = computeMarkdown(newBlocks);
+
+      setDocumentState({
+        blocks: newBlocks,
+        markdown,
+      });
+
       return `Zastąpiono zawartość dokumentu ${newBlocks.length} nowymi blokami`;
     },
   });
 
-  const handleEditorChange = (blocks: Block[]) => {
-    setContent(blocks);
-  };
+  const handleEditorChange = useCallback((doc: EditorDocument) => {
+    setDocumentState({
+      blocks: ensureBlockIds(doc.blocks),
+      markdown: doc.markdown,
+    });
+  }, []);
 
   return (
     <div className="flex h-screen w-full overflow-hidden">
-      {/* Edytor na pełny ekran */}
       <div className="flex-1 flex flex-col h-full overflow-hidden">
-        <Editor content={content} onChange={handleEditorChange} />
+        <Editor document={documentState} onChange={handleEditorChange} onEditorReady={setEditor} />
       </div>
 
-      {/* Asystent CopilotKit w sidebarze */}
       <CopilotSidebar
         instructions={`Jesteś pomocnym asystentem edytora tekstu. Możesz pomóc użytkownikowi w edycji dokumentu poprzez:
 

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -1,0 +1,133 @@
+import { Block, BlockNoteEditor, blocksToMarkdown, markdownToBlocks } from "@blocknote/core";
+
+export type EditorBlock = Block<any, any, any>;
+
+export interface EditorDocument {
+  blocks: EditorBlock[];
+  markdown: string;
+}
+
+const getDocumentRef = () => {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+  return document;
+};
+
+export const ensureBlockIds = (blocks: EditorBlock[]): EditorBlock[] => {
+  return blocks.map((block) => ({
+    ...block,
+    id: block.id ?? crypto.randomUUID(),
+    children: block.children ? ensureBlockIds(block.children as EditorBlock[]) : [],
+  }));
+};
+
+export const serializeBlocksToMarkdown = (
+  blocks: EditorBlock[],
+  editor: BlockNoteEditor<any, any, any>
+): string => {
+  return blocksToMarkdown(blocks, editor.schema, editor, {
+    document: getDocumentRef(),
+  });
+};
+
+export const parseMarkdownToBlocks = (
+  markdown: string,
+  editor: BlockNoteEditor<any, any, any>
+): EditorBlock[] => {
+  if (!markdown.trim()) {
+    return [];
+  }
+
+  const parsed = markdownToBlocks(markdown, editor.schema) as EditorBlock[];
+  return ensureBlockIds(parsed);
+};
+
+export const extractPlainTextFromBlock = (block: EditorBlock): string => {
+  const collectText = (currentBlock: EditorBlock): string => {
+    const inlineContent = Array.isArray(currentBlock.content)
+      ? (currentBlock.content as any[])
+      : [];
+
+    const inlineText = inlineContent
+      .map((inline) => {
+        if (!inline) {
+          return "";
+        }
+
+        if (inline.type === "text" || typeof inline.text === "string") {
+          return inline.text || "";
+        }
+
+        if (Array.isArray(inline.children)) {
+          return inline.children.map((child: any) => child.text || "").join("");
+        }
+
+        return "";
+      })
+      .join("");
+
+    const childrenText = Array.isArray(currentBlock.children)
+      ? (currentBlock.children as EditorBlock[]).map(collectText).join("\n")
+      : "";
+
+    return [inlineText, childrenText].filter(Boolean).join("\n").trim();
+  };
+
+  return collectText(block);
+};
+
+export const createBlockFromMarkdownSnippet = (
+  markdown: string,
+  editor: BlockNoteEditor<any, any, any>
+): EditorBlock => {
+  const [firstBlock] = parseMarkdownToBlocks(markdown, editor);
+
+  if (firstBlock) {
+    return firstBlock;
+  }
+
+  return {
+    id: crypto.randomUUID(),
+    type: "paragraph",
+    props: {},
+    content: [
+      {
+        type: "text",
+        text: markdown,
+      } as any,
+    ],
+    children: [],
+  } as EditorBlock;
+};
+
+export const buildMarkdownForBlockType = (text: string, type?: string) => {
+  switch (type) {
+    case "heading":
+    case "heading1":
+    case "heading_1":
+      return `# ${text}`;
+    case "heading2":
+    case "heading_2":
+      return `## ${text}`;
+    case "heading3":
+    case "heading_3":
+      return `### ${text}`;
+    case "quote":
+      return `> ${text}`;
+    case "code":
+    case "codeblock":
+    case "code_block":
+      return "```\n" + text + "\n```";
+    case "numbered_list":
+    case "numberedList":
+    case "ordered_list":
+      return `1. ${text}`;
+    case "bullet_list":
+    case "bulletList":
+    case "unordered_list":
+      return `- ${text}`;
+    default:
+      return text;
+  }
+};


### PR DESCRIPTION
## Summary
- maintain a shared document state that tracks both block data and markdown for the editor
- expose markdown-aware block helpers so Copilot actions can insert, update, or replace blocks using markdown semantics
- update the editor component to emit markdown on change and sync external updates via the shared document state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df44a6d95c8327b968d1174ea250a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Editor now works with full documents, synchronizing blocks and live Markdown.
  * Added editor-ready lifecycle hook for faster, more reliable startup.
  * Enhanced AI assistant integration with richer context (blocks + Markdown) and block-level actions.
* Bug Fixes
  * Prevents accidental content wipes when incoming content is empty.
  * Preserves block identities during edits for stable behavior.
  * Adds bounds checks and clearer errors for invalid operations.
* Refactor
  * Streamlined content synchronization for better performance and consistency.
  * Consolidated block/Markdown conversions for more accurate exports and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->